### PR TITLE
[FIX] Undefined index: HTTP_HOST

### DIFF
--- a/src/Http/QuoPayload.php
+++ b/src/Http/QuoPayload.php
@@ -160,7 +160,7 @@ class QuoPayload
      */
     private function getSenderDomain()
     {
-        return $_SERVER['HTTP_HOST'];
+        return isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : 'localhost';
     }
 
     /**


### PR DESCRIPTION
When running in cli you get a E_NOTICE Undefined index: HTTP_HOST and depending on your projects global error handling the code will halt and nothing is reported in the Quo electron app.

#### Proposed solution/change

Small `isset` check or `??` null check could be used and in place default to `localhost`
